### PR TITLE
added overload on Input.getLocalPosition to accept Group

### DIFF
--- a/src/phaser/input/Input.hx
+++ b/src/phaser/input/Input.hx
@@ -396,7 +396,8 @@ extern class Input {
 	/**
 	 * This will return the local coordinates of the specified displayObject based on the given Pointer.
 	 */
-	@:overload(function (displayObject:phaser.gameobjects.Sprite, pointer:phaser.input.Pointer):phaser.geom.Point {})
+	@:overload(function (displayObject:phaser.gameobjects.Sprite, pointer:phaser.input.Pointer):phaser.geom.Point { } )
+	@:overload(function (displayObject:phaser.core.Group, pointer:phaser.input.Pointer):phaser.geom.Point {})
 	function getLocalPosition (displayObject:phaser.gameobjects.Image, pointer:phaser.input.Pointer):phaser.geom.Point;
 	
 	/**


### PR DESCRIPTION
A Phaser Group , though not able to receive input events on itself, is still accepted as a first arg on getLocalPosition in the .js version to transform the Pointer position.